### PR TITLE
Fix smtp sending

### DIFF
--- a/src/MiddleMail.Delivery.Smtp/SmtpMimeMessageSender.cs
+++ b/src/MiddleMail.Delivery.Smtp/SmtpMimeMessageSender.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MailKit;
@@ -32,8 +33,13 @@ namespace MiddleMail.Delivery.Smtp {
 			// Note: since we don't have an OAuth2 token, disable
 			// the XOAUTH2 authentication mechanism.
 			this.smtpClient.AuthenticationMechanisms.Remove("XOAUTH2");
-
-			await this.smtpClient.AuthenticateAsync(options.Username, options.Password);
+			try {
+				await this.smtpClient.AuthenticateAsync(options.Username, options.Password);
+			} catch(AuthenticationException e) {
+				// if authentication fails we close the connection and try again next time
+				await this.smtpClient.DisconnectAsync(quit: true);
+				throw e;
+			}
 		}
 
 		public async Task SendAsync(MimeMessage message) {

--- a/src/MiddleMail.Delivery.Smtp/SmtpMimeMessageSender.cs
+++ b/src/MiddleMail.Delivery.Smtp/SmtpMimeMessageSender.cs
@@ -53,7 +53,7 @@ namespace MiddleMail.Delivery.Smtp {
 				// reconnect if we are not connected anymore
 				try {
 					await smtpClient.NoOpAsync();
-				} catch (ProtocolException) {
+				} catch (Exception e) when (e is SmtpProtocolException | e is IOException | e is SmtpCommandException) {
 					await this.connectAsync();
 				}
 				await smtpClient.SendAsync(message);


### PR DESCRIPTION
Fixes in `SmtpMimeMessageSender`:

* If authentication fails, disconnect the smptclient and do not try to send via un-authenticated connection
* Catch all valid exceptions when sending `smtp: NoOp`