### PR TITLE
Do not throw a SingleProcessingException when smtp sending fails

### DIFF
--- a/helm/middlemail/Chart.yaml
+++ b/helm/middlemail/Chart.yaml
@@ -5,7 +5,7 @@ description: Transactional Email
 type: application
 
 version: 1.1.0
-appVersion: 0.4.0
+appVersion: 0.4.1
 
 dependencies:
   - name: rabbitmq

--- a/src/MiddleMail.Delivery.Smtp/SmtpDeliverer.cs
+++ b/src/MiddleMail.Delivery.Smtp/SmtpDeliverer.cs
@@ -28,8 +28,6 @@ namespace MiddleMail.Delivery.Smtp {
 			}
 			try {
 				await sender.SendAsync(mimeMessage);
-			} catch (InvalidOperationException e) {
-				throw new MimeMessageSenderException(emailMessage, mimeMessage, e);
 			} catch (Exception e) {
 				throw new GeneralProcessingException(emailMessage, e);
 			}

--- a/tests/Delivery/SmtpDelivererTests.cs
+++ b/tests/Delivery/SmtpDelivererTests.cs
@@ -54,7 +54,7 @@ namespace MiddleMail.Tests.Delivery {
 			messageSenderMock.Verify(s => s.SendAsync(It.IsAny<MimeMessage>()), Times.Never);
 		}
 
-		[Fact]
+		[Fact (Skip = "Disabled because of workaround in 4cbb493b23b628d262dc6a2429d4e88eaa5d673c")]
 		public async void ThrowsIfInvalidSendFails() {
 			var emailMessage = FakerFactory.EmailMessageFaker.Generate();
 			emailMessage.Subject = MESSAGE_INVALID;


### PR DESCRIPTION
This is meant to be a temporary workaround: There is a bug in
SmtpMimeMessageSender.SendAsync leading to System.InvalidOperationException: The SmtpClient is already connected.

It is too dangerous anyway to throw a SingleProcessingException for
every InvalidOperationException.