### PR TITLE
Change SendEmailAsync to return bool

### DIFF
--- a/src/MiddleMail.Client.RabbitMQ/MiddleMailClient.cs
+++ b/src/MiddleMail.Client.RabbitMQ/MiddleMailClient.cs
@@ -27,12 +27,13 @@ namespace MiddleMail.Client.RabbitMQ {
 		/// it is processed by a MiddleMail instance running a RabbitMQ Message Source.
 		/// Might throw if there was an exception during publishing.
 		/// </summary>
-		public async Task SendEmailAsync(EmailMessage emailMessage) {
+		public async Task<bool> SendEmailAsync(EmailMessage emailMessage) {
 			try {
 				await bus.PublishAsync(emailMessage);
+				return true;
 			} catch(Exception e) {
 				logger.LogError("Exception during publishing to rabbitmq queue.", e);
-				throw;
+				return false;
 			}
 		}
 		

--- a/src/MiddleMail.Client.RabbitMQ/MiddleMailClient.cs
+++ b/src/MiddleMail.Client.RabbitMQ/MiddleMailClient.cs
@@ -25,14 +25,14 @@ namespace MiddleMail.Client.RabbitMQ {
 		/// <summary>
 		/// Sends an email by publishing it to RabbitMQ. A published email will wait in a queue on RabbitMQ until 
 		/// it is processed by a MiddleMail instance running a RabbitMQ Message Source.
-		/// Might throw if there was an exception during publishing.
+		/// Returns true if the email is published to RabbitMQ successfully, false otherwise.
 		/// </summary>
 		public async Task<bool> SendEmailAsync(EmailMessage emailMessage) {
 			try {
 				await bus.PublishAsync(emailMessage);
 				return true;
 			} catch(Exception e) {
-				logger.LogError("Exception during publishing to rabbitmq queue.", e);
+				logger.LogError("Failed to publish to rabbitmq queue.", e);
 				return false;
 			}
 		}

--- a/tests/Client/MiddleMailClientTests.cs
+++ b/tests/Client/MiddleMailClientTests.cs
@@ -25,27 +25,25 @@ namespace MiddleMail.Tests.Client {
 		}
 
 		[Fact]
-		public async Task SendEmailAsync_ShouldThrowAndLogException_WhenRabbitMQBusThrowsException() {
+		public async Task SendEmailAsync_ShouldReturnFalse_WhenRabbitMQBusThrowsException() {
 			// Arrange
 			var middleMailClient = createMiddleMailClient(UNREACHABLE_CONNECTIONSTRING);
 			var emailMessage = FakerFactory.EmailMessageFaker.Generate();
 
-			// Act / Assert
-			await Assert.ThrowsAnyAsync<Exception>(() => middleMailClient.SendEmailAsync(emailMessage));
+			//Assert / Act
+			Assert.False(await middleMailClient.SendEmailAsync(emailMessage));
 			loggerMock.VerifyLog(m => m.LogError(It.IsAny<string>(), It.IsAny<Exception>()), Times.Once);
 
 		}
 
 		[Fact]
-		public async Task SendEmailAsync_ShouldNotThrowNotLogException_WhenMessageSuccessfullyPublished() {
+		public async Task SendEmailAsync_ShouldReturnTrue_WhenMessageSuccessfullyPublished() {
 			// Arrange
 			var middleMailClient = createMiddleMailClient(RabbitMQTestHelpers.ConnectionString);
 			var emailMessage = FakerFactory.EmailMessageFaker.Generate();
 
-			// Act
-			await middleMailClient.SendEmailAsync(emailMessage);
-
-			// Assert
+			// Assert / Act
+			Assert.True(await middleMailClient.SendEmailAsync(emailMessage));
 			loggerMock.VerifyLog(m => m.LogError(It.IsAny<string>(), It.IsAny<Exception>()), Times.Never);
 		}
 	}

--- a/tests/Client/MiddleMailClientTests.cs
+++ b/tests/Client/MiddleMailClientTests.cs
@@ -30,10 +30,12 @@ namespace MiddleMail.Tests.Client {
 			var middleMailClient = createMiddleMailClient(UNREACHABLE_CONNECTIONSTRING);
 			var emailMessage = FakerFactory.EmailMessageFaker.Generate();
 
-			//Assert / Act
-			Assert.False(await middleMailClient.SendEmailAsync(emailMessage));
-			loggerMock.VerifyLog(m => m.LogError(It.IsAny<string>(), It.IsAny<Exception>()), Times.Once);
+			// Act
+			var response = await middleMailClient.SendEmailAsync(emailMessage);
 
+			// Assert
+			Assert.False(response);
+			loggerMock.VerifyLog(m => m.LogError(It.IsAny<string>(), It.IsAny<Exception>()), Times.Once);
 		}
 
 		[Fact]
@@ -42,8 +44,11 @@ namespace MiddleMail.Tests.Client {
 			var middleMailClient = createMiddleMailClient(RabbitMQTestHelpers.ConnectionString);
 			var emailMessage = FakerFactory.EmailMessageFaker.Generate();
 
-			// Assert / Act
-			Assert.True(await middleMailClient.SendEmailAsync(emailMessage));
+			// Act
+			var response = await middleMailClient.SendEmailAsync(emailMessage);
+
+			// Assert
+			Assert.True(response);
 			loggerMock.VerifyLog(m => m.LogError(It.IsAny<string>(), It.IsAny<Exception>()), Times.Never);
 		}
 	}


### PR DESCRIPTION
 In `MiddleMailClient.cs` when `SendEmailAsync` fails to publish to RabbitMQ it throws an exception.
Clients should be able to detect whether publishing was successful or not. So, we've decided to stop throwing exceptions and change `SendEmailAsync` method to return a boolean depending on the success of publishing to RabbitMQ.

And lastly, update the corresponding tests for the `SendEmailAsync` method.