### PR TITLE
Fix broken bitnami chart source

### DIFF
--- a/helm/middlemail/Chart.lock
+++ b/helm/middlemail/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
-  version: ~7.5.0
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+  version: 7.5.8
 - name: elasticsearch
-  repository: https://charts.bitnami.com/bitnami
-  version: ~12.3.5
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+  version: 12.3.6
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: ~10.7.2
-digest: sha256:7b4394dc272faf3f665e97f117da498b45586a0efdafc43946c1567689617903
-generated: "2020-07-27T18:00:54.509424+02:00"
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+  version: 10.7.17
+digest: sha256:5615acec43e8784c11aff95fdddae92667c798df21a013c88a693fc748ef6fbb
+generated: "2023-10-12T15:23:47.917219829+02:00"

--- a/helm/middlemail/Chart.yaml
+++ b/helm/middlemail/Chart.yaml
@@ -10,12 +10,12 @@ appVersion: 0.5.0
 dependencies:
   - name: rabbitmq
     version: "~7.5.0"
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     condition: rabbitmq.provision
   - name: elasticsearch
     version: "~12.3.5"
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     condition: elasticsearch.provision
   - name: redis
     version: "~10.7.2"
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami


### PR DESCRIPTION
To save CDN cost, bitnami decided to drop old chart versions from the list advertised through cloudfront which breaks our CI.

We resolved the issue by using GitHub directly as a source makes these charts available again in `Chart.yaml`.