### PR TITLE
Provide cc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ The following table lists the configurable parameters for MiddleMail. To pass th
 | `REDIS_INSTANCE_NAME` | The Redis instance name |
 | `DISABLE_SMTP` | Do not actually send anything via SMTP. |
 
+## Basic Local Setup
+This setup assumes the use of Visual Studio Code as an editor. If not using 
+VSCode, configure environment variables in whatever way is appropriate for your 
+preferred launch mechanism. This setup also runs the dependencies in Docker.
+You don't have to do this, but it sure is convenient.
+
+1. Clone this repository.
+1. Create a `launch.json` in which you configure the environment variables described above in the Configuration section. This `launch.json` should target the build of the `MiddleMail.Server` project, since that's the standalone process. You probably also need to create a `tasks.json` to run it, with a build task, but that's no different from the standard `launch.json` setup.
+1. Run the `docker-compose.dev.yml` file to spin up dependency services. It mainly includes:
+  - A RabbitMQ container as an email message queue.
+  - An Elasticsearch container as a storage solution.
+    - _Note that if you're not using Elasticsearch, you can edit the services found in `MiddleMail/Server/Program.cs` to replace `ElasticSearchStorage` in `services.AddSingleton<IStorage, ElasticSearchStorage>();` with `MemoryStorage`, an in-memory storage solution. You will also need to edit the dependencies in `MiddleMail.Server.csproj` to depend on `MiddleMail.Storage.Memory` instead of `MiddleMail.Storage.Elastic`._
+  - A Redis container as a caching solution.
+  - An smtp4dev container as an SMTP server for development and testing.
+1. Run the MiddleMailServer process (with your `launch.json`).
+1. Optional: Test your new MiddleMail instance using the `tools/EmailMessageGenerator` project to send test emails.
+
+
 ## Tools
 
 | Project               | Description                    |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,38 @@
+# Docker compose file for developers to run the necessary background services.
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
+  elasticsearch:
+    image: elasticsearch:8.14.3
+    environment:
+      - discovery.type=single-node
+      - xpack.security.http.ssl.enabled=false
+      - xpack.license.self_generated.type=trial
+      - xpack.security.enabled=false
+    ports:
+      - "127.0.0.1:9200:9200"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+
+  redis:
+    image: redis
+    ports:
+      - "127.0.0.1:6379:6379"
+
+  smtp4dev:
+    image: rnwood/smtp4dev
+    ports:
+      - "127.0.0.1:5000:80"
+      - "127.0.0.1:2525:25"
+
+volumes:
+  rabbitmq_data:
+  elasticsearch_data:

--- a/helm/middlemail/Chart.yaml
+++ b/helm/middlemail/Chart.yaml
@@ -5,7 +5,7 @@ description: Transactional Email
 type: application
 
 version: 1.1.0
-appVersion: 0.5.0
+appVersion: 0.6.0
 
 dependencies:
   - name: rabbitmq

--- a/src/MiddleMail.Client.RabbitMQ/MiddleMail.Client.RabbitMQ.csproj
+++ b/src/MiddleMail.Client.RabbitMQ/MiddleMail.Client.RabbitMQ.csproj
@@ -4,7 +4,7 @@
     <WarningAsErrors>true</WarningAsErrors>
     <RootNamespace>MiddleMail.Client.RabbitMQ</RootNamespace>
     <PackageId>MiddleMail.Client.RabbitMQ</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.6.0</Version>
     <Authors>Miaplaza Inc.</Authors>
     <Company>MiaPlaza</Company>
     <Copyright>Copyright ©2020 Miaplaza Inc.</Copyright>

--- a/src/MiddleMail.Client.RabbitMQ/MiddleMailClient.cs
+++ b/src/MiddleMail.Client.RabbitMQ/MiddleMailClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Threading.Tasks;
 using EasyNetQ;
 using Microsoft.Extensions.Options;
@@ -31,12 +31,12 @@ namespace MiddleMail.Client.RabbitMQ {
 			try {
 				await bus.PublishAsync(emailMessage);
 				return true;
-			} catch(Exception e) {
+			} catch (Exception e) {
 				logger.LogError("Failed to publish to rabbitmq queue.", e);
 				return false;
 			}
 		}
-		
+
 		public void Dispose() {
 			bus?.Dispose();
 		}

--- a/src/MiddleMail.Delivery.Smtp/MimeMessageBuilder.cs
+++ b/src/MiddleMail.Delivery.Smtp/MimeMessageBuilder.cs
@@ -30,6 +30,8 @@ namespace MiddleMail.Delivery.Smtp {
 			mimeMessage.From.Add(new MailboxAddress(emailMessage.From.name, emailMessage.From.address));
 			mimeMessage.To.Add(new MailboxAddress(emailMessage.To.name, emailMessage.To.address));
 
+			emailMessage.Cc.ForEach(cc => mimeMessage.Cc.Add(new MailboxAddress(cc.name, cc.address)));
+
 			if(emailMessage.ReplyTo.HasValue) {
 				mimeMessage.ReplyTo.Add(new MailboxAddress(emailMessage.ReplyTo.Value.name, emailMessage.ReplyTo.Value.address));
 			}

--- a/src/MiddleMail.Delivery.Smtp/MimeMessageBuilder.cs
+++ b/src/MiddleMail.Delivery.Smtp/MimeMessageBuilder.cs
@@ -6,7 +6,7 @@ using MimeKit;
 using Microsoft.Extensions.Options;
 
 namespace MiddleMail.Delivery.Smtp {
-	
+
 	/// <summary>
 	/// Builds MIME messages from an <see cref="EMailMessage" />.
 	/// </summary>
@@ -22,22 +22,22 @@ namespace MiddleMail.Delivery.Smtp {
 		/// Note that <paramref name="emailMessage" /> must specify at least a plaintext version.
 		/// </summary>
 		public MimeMessage Create(EmailMessage emailMessage) {
-			if(emailMessage.PlainText == null) {
+			if (emailMessage.PlainText == null) {
 				throw new ArgumentException($"EmailMessage should always contains a Plaintext, but it is null.", nameof(emailMessage));
 			}
-			
+
 			var mimeMessage = new MimeMessage();
 			mimeMessage.From.Add(new MailboxAddress(emailMessage.From.name, emailMessage.From.address));
 			mimeMessage.To.Add(new MailboxAddress(emailMessage.To.name, emailMessage.To.address));
 
 			emailMessage.Cc?.ForEach(cc => mimeMessage.Cc.Add(new MailboxAddress(cc.name, cc.address)));
 
-			if(emailMessage.ReplyTo.HasValue) {
+			if (emailMessage.ReplyTo.HasValue) {
 				mimeMessage.ReplyTo.Add(new MailboxAddress(emailMessage.ReplyTo.Value.name, emailMessage.ReplyTo.Value.address));
 			}
 			mimeMessage.Subject = emailMessage.Subject;
 
-			if(emailMessage.HtmlText == null) {
+			if (emailMessage.HtmlText == null) {
 				createBodyPlainText(emailMessage, mimeMessage);
 			} else {
 				createBodyMultipart(emailMessage, mimeMessage);
@@ -58,7 +58,7 @@ namespace MiddleMail.Delivery.Smtp {
 		private void createBodyMultipart(EmailMessage emailMessage, MimeMessage message) {
 			var bodyBuilder = new BodyBuilder();
 			bodyBuilder.HtmlBody = emailMessage.HtmlText;
-			bodyBuilder.TextBody =  emailMessage.PlainText;
+			bodyBuilder.TextBody = emailMessage.PlainText;
 
 			message.Body = bodyBuilder.ToMessageBody();
 		}
@@ -66,7 +66,7 @@ namespace MiddleMail.Delivery.Smtp {
 		private void setHeaders(EmailMessage emailMessage, MimeMessage message) {
 			foreach (var item in emailMessage.Headers) {
 				// do not override any headers
-				var header = message.Headers.FirstOrDefault(h => h.Field == item.Key);	
+				var header = message.Headers.FirstOrDefault(h => h.Field == item.Key);
 				if (header == null) {
 					message.Headers.Add(item.Key, item.Value);
 				}

--- a/src/MiddleMail.Delivery.Smtp/MimeMessageBuilder.cs
+++ b/src/MiddleMail.Delivery.Smtp/MimeMessageBuilder.cs
@@ -30,7 +30,7 @@ namespace MiddleMail.Delivery.Smtp {
 			mimeMessage.From.Add(new MailboxAddress(emailMessage.From.name, emailMessage.From.address));
 			mimeMessage.To.Add(new MailboxAddress(emailMessage.To.name, emailMessage.To.address));
 
-			emailMessage.Cc.ForEach(cc => mimeMessage.Cc.Add(new MailboxAddress(cc.name, cc.address)));
+			emailMessage.Cc?.ForEach(cc => mimeMessage.Cc.Add(new MailboxAddress(cc.name, cc.address)));
 
 			if(emailMessage.ReplyTo.HasValue) {
 				mimeMessage.ReplyTo.Add(new MailboxAddress(emailMessage.ReplyTo.Value.name, emailMessage.ReplyTo.Value.address));

--- a/src/MiddleMail.Delivery.Smtp/SmtpDeliverer.cs
+++ b/src/MiddleMail.Delivery.Smtp/SmtpDeliverer.cs
@@ -23,7 +23,7 @@ namespace MiddleMail.Delivery.Smtp {
 			MimeMessage mimeMessage;
 			try {
 				mimeMessage = builder.Create(emailMessage);
-			} catch(Exception e) {
+			} catch (Exception e) {
 				throw new MimeMessageBuilderException(emailMessage, e);
 			}
 			try {

--- a/src/MiddleMail.Model/EmailMessage.cs
+++ b/src/MiddleMail.Model/EmailMessage.cs
@@ -54,7 +54,7 @@ namespace MiddleMail.Model {
 			Id = id;
 			From = from;
 			To = to;
-			Cc = cc;
+			Cc = cc ?? new List<(string name, string address)>();
 			ReplyTo = replyTo;
 			Subject = subject;
 			PlainText = plainText;

--- a/src/MiddleMail.Model/EmailMessage.cs
+++ b/src/MiddleMail.Model/EmailMessage.cs
@@ -12,6 +12,7 @@ namespace MiddleMail.Model {
 		public Guid Id { get; set; }
 		public (string name, string address) From { get; set; }
 		public (string name, string address) To { get; set; }
+		public List<(string name, string address)> Cc { get; set; }
 		public (string name, string address)? ReplyTo { get; set; }
 		public string Subject { get; set; }
 		public string PlainText { get; set; }
@@ -36,9 +37,10 @@ namespace MiddleMail.Model {
 
 		public EmailMessage() {}
 
-		public EmailMessage(Guid id, (string name, string address) from, (string name, string address) to, 
-			(string name, string address)? replyTo, string subject, string plainText, string htmlText, 
-			List<string> tags, Dictionary<string, string> headers, int retryCount = 0, bool store = true) {
+		public EmailMessage(Guid id, (string name, string address) from, (string name, string address) to,
+			List<(string name, string address)> cc, (string name, string address)? replyTo, string subject,
+			string plainText, string htmlText, List<string> tags, Dictionary<string, string> headers,
+			int retryCount = 0, bool store = true) {
 
 			if (String.IsNullOrEmpty(from.address)) {
 				throw new ArgumentException("Must specify a from email address.", nameof(from));
@@ -52,6 +54,7 @@ namespace MiddleMail.Model {
 			Id = id;
 			From = from;
 			To = to;
+			Cc = cc;
 			ReplyTo = replyTo;
 			Subject = subject;
 			PlainText = plainText;

--- a/src/MiddleMail.Model/MiddleMail.Model.csproj
+++ b/src/MiddleMail.Model/MiddleMail.Model.csproj
@@ -5,7 +5,7 @@
     <WarningAsErrors>true</WarningAsErrors>
     <RootNamespace>MiddleMail.Model</RootNamespace>
     <PackageId>MiddleMail.Model</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.6.0</Version>
     <Authors>Miaplaza Inc.</Authors>
     <Company>MiaPlaza</Company>
     <Copyright>Copyright ©2020 Miaplaza Inc.</Copyright>

--- a/src/MiddleMail.Storage.ElasticSearch/ElasticSearchStorage.cs
+++ b/src/MiddleMail.Storage.ElasticSearch/ElasticSearchStorage.cs
@@ -14,7 +14,7 @@ namespace MiddleMail.Storage.ElasticSearch {
 	/// Use <see cref="ElasticSearchStorageOptions" /> to configure the connection and index.
 	/// </summary>
 	public class ElasticSearchStorage : IMailStorage {
-		
+
 		private readonly ElasticClient client;
 		private readonly ElasticSearchStorageOptions options;
 		public ElasticSearchStorage(IOptions<ElasticSearchStorageOptions> options) {
@@ -28,13 +28,13 @@ namespace MiddleMail.Storage.ElasticSearch {
 		}
 
 		public async Task SetProcessedAsync(EmailMessage emailMessage) {
-			await updateOrCreateAsync(emailMessage, 
+			await updateOrCreateAsync(emailMessage,
 				update: (EmailDocument emailDocument) => { },
 				create: () => new EmailDocument(emailMessage));
 		}
 
 		public async Task SetSentAsync(EmailMessage emailMessage) {
-			await updateOrCreateAsync(emailMessage, 
+			await updateOrCreateAsync(emailMessage,
 				update: (EmailDocument emailDocument) => {
 					emailDocument.Sent = DateTime.UtcNow;
 				},
@@ -42,7 +42,7 @@ namespace MiddleMail.Storage.ElasticSearch {
 		}
 
 		public async Task SetErrorAsync(EmailMessage emailMessage, string errorMessage) {
-			await updateOrCreateAsync(emailMessage, 
+			await updateOrCreateAsync(emailMessage,
 				update: (EmailDocument emailDocument) => {
 					emailDocument.Error = errorMessage;
 				},
@@ -51,7 +51,7 @@ namespace MiddleMail.Storage.ElasticSearch {
 
 		private async Task updateOrCreateAsync(EmailMessage emailMessage, Action<EmailDocument> update, Func<EmailDocument> create) {
 			var emailDocument = await searchDocument(emailMessage.Id);
-			if(emailDocument != null) {
+			if (emailDocument != null) {
 				if (emailDocument.Sent != null) {
 					throw new EMailMessageAlreadySentStorageException(emailMessage);
 				}
@@ -71,14 +71,14 @@ namespace MiddleMail.Storage.ElasticSearch {
 			var existingDocument = await searchDocument(emailMessage.Id);
 			return existingDocument?.Sent != null;
 		}
-		
+
 		public async Task<string> GetErrorAsync(EmailMessage emailMessage) {
 			var existingDocument = await searchDocument(emailMessage.Id);
-			return existingDocument?.Error;		
+			return existingDocument?.Error;
 		}
 
 		private string index => options.Index;
-		
+
 		private async Task<EmailDocument> searchDocument(Guid id) {
 			var response = await client.SearchAsync<EmailDocument>(s => s
 				.Index(index)
@@ -86,7 +86,7 @@ namespace MiddleMail.Storage.ElasticSearch {
 				.Term(c => c
 					.Field(p => p.Id)
 					.Value(id))));
-								
+
 			return response.Documents.SingleOrDefault();
 		}
 	}

--- a/src/MiddleMail.Storage.ElasticSearch/EmailDocument.cs
+++ b/src/MiddleMail.Storage.ElasticSearch/EmailDocument.cs
@@ -20,6 +20,8 @@ namespace MiddleMail.Storage.ElasticSearch {
 		public string FromAddress { get; set; }
 		public string ToName { get; set; }
 		public string ToAddress { get; set; }
+		public List<string> CcNames { get; set; }
+		public List<string> CcAddresses { get; set; }
 		public string ReplyToName { get; set; }
 		public string ReplyToAddress { get; set; }
 		public string Subject { get; set; }
@@ -36,6 +38,8 @@ namespace MiddleMail.Storage.ElasticSearch {
 			FromAddress = emailMessage.From.address;
 			ToName = emailMessage.To.name;
 			ToAddress = emailMessage.To.address;
+			CcNames = emailMessage.Cc.ConvertAll(x => x.name);
+			CcAddresses = emailMessage.Cc.ConvertAll(x => x.address);
 			ReplyToName = emailMessage.ReplyTo?.name;
 			ReplyToAddress = emailMessage.ReplyTo?.address;
 

--- a/src/MiddleMail.Storage.Memory/MemoryStorage.cs
+++ b/src/MiddleMail.Storage.Memory/MemoryStorage.cs
@@ -11,7 +11,7 @@ namespace MiddleMail.Storage.Memory {
 	/// A reference implementation for <see cref="IMailStorage" /> backed by a dictionary in memory.
 	/// </summary>
 	public class MemoryStorage : IMailStorage {
-			
+
 		private readonly ConcurrentDictionary<EmailMessage, (bool sent, string error)> storage;
 
 		public MemoryStorage() {
@@ -19,8 +19,8 @@ namespace MiddleMail.Storage.Memory {
 		}
 
 		public Task SetProcessedAsync(EmailMessage emailMessage) {
-			storage.AddOrUpdate(emailMessage, 
-				addValue: (false, null), 
+			storage.AddOrUpdate(emailMessage,
+				addValue: (false, null),
 				updateValueFactory: (EmailMessage key, (bool sent, string error) value) => {
 					if (value.sent) {
 						throw new EMailMessageAlreadySentStorageException(emailMessage);
@@ -32,8 +32,8 @@ namespace MiddleMail.Storage.Memory {
 		}
 
 		public Task SetSentAsync(EmailMessage emailMessage) {
-			storage.AddOrUpdate(emailMessage, 
-				addValue: (true, null), 
+			storage.AddOrUpdate(emailMessage,
+				addValue: (true, null),
 				updateValueFactory: (EmailMessage key, (bool sent, string error) value) => {
 					if (value.sent) {
 						throw new EMailMessageAlreadySentStorageException(emailMessage);
@@ -45,7 +45,7 @@ namespace MiddleMail.Storage.Memory {
 		}
 
 		public Task SetErrorAsync(EmailMessage emailMessage, string errorMessage) {
-			storage.AddOrUpdate(emailMessage, 
+			storage.AddOrUpdate(emailMessage,
 				addValue: (false, errorMessage),
 				updateValueFactory: (EmailMessage key, (bool sent, string error) value) => {
 					if (value.sent) {
@@ -56,7 +56,7 @@ namespace MiddleMail.Storage.Memory {
 			);
 			return Task.CompletedTask;
 		}
-		
+
 		public Task<bool?> GetSentAsync(EmailMessage emailMessage) {
 			var found = storage.TryGetValue(emailMessage, out var value);
 			if (found) {

--- a/src/MiddleMail/IMailStorage.cs
+++ b/src/MiddleMail/IMailStorage.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using MiddleMail.Model;
 
 namespace MiddleMail {
-	
+
 	/// <summary>
 	/// A storage to persist email activity. When calling any of the methods that set data, the order must be kept.
 	/// Writing data does not need to be instantly and might not be reflected when reading it directly back.
@@ -14,7 +14,7 @@ namespace MiddleMail {
 		/// This can happen multiple times.
 		/// </summary>
 		Task SetProcessedAsync(EmailMessage emailMessage);
-		
+
 		/// <summary>
 		/// Store that an <see cref="EmailMessage" /> was successfully sent.
 		/// </summary>

--- a/src/MiddleMail/MessageProcessor.cs
+++ b/src/MiddleMail/MessageProcessor.cs
@@ -35,30 +35,30 @@ namespace MiddleMail {
 			string cached = null;
 			try {
 				cached = await cache.GetStringAsync(emailMessage.Id.ToString());
-			} catch(Exception e) {
+			} catch (Exception e) {
 				throw new GeneralProcessingException(emailMessage, e);
 			}
 
-			if(cached != null) {
+			if (cached != null) {
 				logger.LogInformation($"Caught duplicate email {emailMessage.Id}");
 				return;
 			}
 
-			if(emailMessage.Store) {
+			if (emailMessage.Store) {
 				await tryStoreOrLogAsync(() => storage.SetProcessedAsync(emailMessage));
 			}
 			try {
 				await deliverer.DeliverAsync(emailMessage);
-			} catch (Exception e){
-				if(emailMessage.Store) {
+			} catch (Exception e) {
+				if (emailMessage.Store) {
 					await tryStoreOrLogAsync(() => storage.SetErrorAsync(emailMessage, e.ToString()));
 				}
 				throw;
 			}
-			
+
 			// if the cache throws an exception we do not rethrow a GeneralProcessingException here because the message has already been delivered
 			await cache.SetStringAsync(emailMessage.Id.ToString(), "t");
-			if(emailMessage.Store) {
+			if (emailMessage.Store) {
 				await tryStoreOrLogAsync(() => storage.SetSentAsync(emailMessage));
 			}
 		}
@@ -66,7 +66,7 @@ namespace MiddleMail {
 		private async Task tryStoreOrLogAsync(Func<Task> storeFunc) {
 			try {
 				await storeFunc();
-			} catch(Exception e) {
+			} catch (Exception e) {
 				logger.LogError(e, "Exception while storing EmailMessage.");
 			}
 		}

--- a/src/MiddleMail/MessageProcessor.cs
+++ b/src/MiddleMail/MessageProcessor.cs
@@ -15,7 +15,7 @@ namespace MiddleMail {
 	/// Many distributed system do not guarantee exactly-once delivery (such as RabbitMQ). We therefore only require 
 	/// at-least-once delivery for an <see cref="IMessageSource" />. That means that a duplicate message could end up here.
 	/// As it is rather critical that emails are delivered exactly-once we must detect duplicates. This is done by caching 
-	/// successfully sent emais by their id and checking the cache before we even start processing. This requires that pro-
+	/// successfully sent emails by their id and checking the cache before we even start processing. This requires that pro-
 	/// cessing tasks always run until completion and are not interrupted.
 	/// </remarks>
 	public class MessageProcessor : IMessageProcessor {

--- a/src/MiddleMail/MiddleMail.csproj
+++ b/src/MiddleMail/MiddleMail.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6</TargetFramework>
     <WarningAsErrors>true</WarningAsErrors>
     <PackageId>MiddleMail</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.6.0</Version>
     <Authors>Miaplaza Inc.</Authors>
     <Company>MiaPlaza</Company>
     <Copyright>Copyright ©2020 Miaplaza Inc.</Copyright>

--- a/src/MiddleMail/MiddleMailService.cs
+++ b/src/MiddleMail/MiddleMailService.cs
@@ -14,7 +14,7 @@ namespace MiddleMail {
 	/// Implements a graceful shutdown by waiting for all processing tasks to finish work if cancellation is requested.
 	/// </summary>
 	public class MiddleMailService : BackgroundService {
-		
+
 		private IMessageProcessor processor;
 		private readonly ILogger<MiddleMailService> logger;
 		private readonly IMessageSource messageSource;
@@ -36,26 +36,26 @@ namespace MiddleMail {
 
 				// wait for all consumer tasks to finish
 				// this is important: a consumer task is only idempotent if does not get canceled
-				while(consumerTasksPending != 0) {
+				while (consumerTasksPending != 0) {
 					logger.LogInformation($"Waiting for {consumerTasksPending} Tasks to finish.");
 					await Task.Delay(25);
 				}
 			}
 		}
 
-		private async Task processAsync(EmailMessage emailMessage ) {
+		private async Task processAsync(EmailMessage emailMessage) {
 			logger.LogDebug($"Start processing email message {emailMessage.Id}");
 			Interlocked.Increment(ref consumerTasksPending);
 			try {
 				await processor.ProcessAsync(emailMessage);
 				logger.LogDebug($"Successfully processed email message {emailMessage.Id}");
-			} catch(SingleProcessingException e) {
+			} catch (SingleProcessingException e) {
 				logger.LogError(e, $"Delivery error for message {emailMessage.Id}");
 				throw;
-			} catch(GeneralProcessingException e) {
+			} catch (GeneralProcessingException e) {
 				logger.LogError(e, $"General delivery problem for message {emailMessage.Id}");
 				await messageSource.RetryAsync(emailMessage);
-			} catch(Exception e) {
+			} catch (Exception e) {
 				logger.LogError(e, $"Unexpected Exception while processing message {emailMessage.Id}");
 				throw;
 			} finally {

--- a/tests/Delivery/MimeMessageBuilderTests.cs
+++ b/tests/Delivery/MimeMessageBuilderTests.cs
@@ -82,7 +82,7 @@ namespace MiddleMail.Tests.Delivery {
 		}
 
 		[Fact]
-		public async void BuilValidEmailMessage() {
+		public async void BuildValidEmailMessage() {
 			var emailMessage = FakerFactory.EmailMessageFaker.Generate();
 			var mimeMessage = builder.Create(emailMessage);
 
@@ -90,7 +90,7 @@ namespace MiddleMail.Tests.Delivery {
 		}
 
 		[Fact]
-		public void BuilInvalidEmailMessageThrows() {
+		public void BuildInvalidEmailMessageThrows() {
 			var emailMessage = FakerFactory.EmailMessageFaker.Generate();
 			emailMessage.From = (null, "<>");
 

--- a/tests/Delivery/MimeMessageBuilderTests.cs
+++ b/tests/Delivery/MimeMessageBuilderTests.cs
@@ -62,7 +62,13 @@ namespace MiddleMail.Tests.Delivery {
 
 				Assert.Equal(emailMessage.To.name ?? string.Empty, parsedMessage.To.First().Name);
 				Assert.Equal(emailMessage.To.address, ((MailboxAddress)parsedMessage.To.First()).Address);
-				
+
+				Assert.Equal(emailMessage.Cc.Count, parsedMessage.Cc.Count);
+				for(int i = 0; i < emailMessage.Cc.Count; i++) {
+					Assert.Equal(emailMessage.Cc[i].name ?? string.Empty, parsedMessage.Cc[i].Name);
+					Assert.Equal(emailMessage.Cc[i].address, ((MailboxAddress)parsedMessage.Cc[i]).Address);
+				}
+
 				if (!emailMessage.ReplyTo.HasValue) {
 					Assert.Empty(parsedMessage.ReplyTo);
 				} else {

--- a/tests/FakerFactory.cs
+++ b/tests/FakerFactory.cs
@@ -15,7 +15,7 @@ namespace MiddleMail.Tests {
 				id: Guid.NewGuid(),
 				from: (f.Name.FullName(), f.Internet.Email()),
 				to: (f.Name.FullName(), f.Internet.Email()),
-				cc: GenerateRandomCcList(f),
+				cc: generateCcList(f),
 				replyTo: (f.Name.FullName(), f.Internet.Email()),
 				subject: f.Lorem.Sentence(),
 				plainText: f.Lorem.Sentences(),
@@ -24,8 +24,14 @@ namespace MiddleMail.Tests {
 				tags: f.Lorem.Words().ToList()
 			));
 
-		private static List<(string name, string address)> GenerateRandomCcList(Faker f) {
-			var count = f.Random.Int(0, 4);
+		/// <summary>
+		/// Generates a list of CC recipients with a fixed size of 3.
+		/// </summary>
+		/// <remarks>
+		/// The size is arbitrary since parsing behavior is consistent across non-empty lists.
+		/// </remarks>
+		private static List<(string name, string address)> generateCcList(Faker f) {
+			const int count = 3;
 			return Enumerable.Range(0, count)
 				.Select(_ => (f.Name.FullName(), f.Internet.Email()))
 				.ToList();

--- a/tests/FakerFactory.cs
+++ b/tests/FakerFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bogus;
 using MiddleMail;
@@ -14,6 +15,7 @@ namespace MiddleMail.Tests {
 				id: Guid.NewGuid(),
 				from: (f.Name.FullName(), f.Internet.Email()),
 				to: (f.Name.FullName(), f.Internet.Email()),
+				cc: new List<(string name, string address)> { (f.Name.FullName(), f.Internet.Email()) },
 				replyTo: (f.Name.FullName(), f.Internet.Email()),
 				subject: f.Lorem.Sentence(),
 				plainText: f.Lorem.Sentences(),

--- a/tests/FakerFactory.cs
+++ b/tests/FakerFactory.cs
@@ -15,13 +15,20 @@ namespace MiddleMail.Tests {
 				id: Guid.NewGuid(),
 				from: (f.Name.FullName(), f.Internet.Email()),
 				to: (f.Name.FullName(), f.Internet.Email()),
-				cc: new List<(string name, string address)> { (f.Name.FullName(), f.Internet.Email()) },
+				cc: GenerateRandomCcList(f),
 				replyTo: (f.Name.FullName(), f.Internet.Email()),
 				subject: f.Lorem.Sentence(),
 				plainText: f.Lorem.Sentences(),
 				htmlText: f.Lorem.Sentences(),
 				headers: null,
 				tags: f.Lorem.Words().ToList()));
+
+		private static List<(string name, string address)> GenerateRandomCcList(Faker f) {
+			var count = f.Random.Int(0, 4);
+			return Enumerable.Range(0, count)
+				.Select(_ => (f.Name.FullName(), f.Internet.Email()))
+				.ToList();
+		}
 
 		public static Faker<MimeMessage> MimeMessageFaker = new Faker<MimeMessage>()
 			.CustomInstantiator(f => new MimeMessage(

--- a/tests/FakerFactory.cs
+++ b/tests/FakerFactory.cs
@@ -21,7 +21,8 @@ namespace MiddleMail.Tests {
 				plainText: f.Lorem.Sentences(),
 				htmlText: f.Lorem.Sentences(),
 				headers: null,
-				tags: f.Lorem.Words().ToList()));
+				tags: f.Lorem.Words().ToList()
+			));
 
 		private static List<(string name, string address)> GenerateRandomCcList(Faker f) {
 			var count = f.Random.Int(0, 4);
@@ -32,9 +33,10 @@ namespace MiddleMail.Tests {
 
 		public static Faker<MimeMessage> MimeMessageFaker = new Faker<MimeMessage>()
 			.CustomInstantiator(f => new MimeMessage(
-				from: new MailboxAddress[] { new MailboxAddress(f.Name.FullName(), f.Internet.Email())},
-				to: new MailboxAddress[] { new MailboxAddress(f.Name.FullName(), f.Internet.Email())},
+				from: new MailboxAddress[] { new MailboxAddress(f.Name.FullName(), f.Internet.Email()) },
+				to: new MailboxAddress[] { new MailboxAddress(f.Name.FullName(), f.Internet.Email()) },
 				subject: f.Lorem.Sentence(),
-				body: new TextPart("plain") { Text = f.Lorem.Sentences(10)}));
+				body: new TextPart("plain") { Text = f.Lorem.Sentences(10) }
+			));
 	}
 }


### PR DESCRIPTION
## Short Summary of the Issue
Currently, the `EmailMessage` API does not support CC recipients. Related issue #37 

## Changes made to Resolve the Issue

- Expands on the `EmailMessage` API to support CCs. This is done by levereging the [CCs property provided by MimeMessage](https://mimekit.net/docs/html/P_MimeKit_MimeMessage_Cc.htm).
- Updated message serialization and deserialization to handle the CC field.
- Updated Elasticsearch document indexing to log the new CC recipients property.
- Ensured compatibility with older messages in the queue by implementing null checks and default empty lists.

### Backward Compatibility Testing
To ensure the changes do not break pending emails in the queue (with the old format lacking CC), the following steps were performed:

1. Spun up **RabbitMQ**, **Redis**, and **smtp4dev** containers.
1. Used `MemoryStorage` instead of `Elastic` for simplified local testing.
1. Built **MiddleMail** with the old message format (from `master`).
1. Ran **MiddleMail Server** to subscribe to **RabbitMQ** and create the exchange.
1. Stopped **MiddleMail Server**.
1. Generated emails into the RabbitMQ queue using `tools/EmailMessageGenerator`.
1. Rebuilt **MiddleMail** with the new message format (including CC support).
1. Ran **MiddleMail Server**.
1. Observed logged emails in `smtp4dev`.


This enabled me to verify that emails without CCs will have a `null` CC value when parsing emails into the new type. Here `null` checks and using empty lists saves the program from throwing a null reference exception.

It also works the other way around (swapping the old/new types). It just drops the added field entirely when parsing into a type with no CC.

I've tested with many more scenarios and as long as the exchange is created, no emails are being dropped and no parsing is failing. Which aligns with [this warning](https://github.com/EasyNetQ/EasyNetQ/wiki/Publish#a-warning)

### Additional Validation in Elasticsearch
- Set up Elasticsearch and verified indices using:
  ```sh
  curl http://127.0.0.1:9200/_cat/indices?v
  ```
- Checked `docs.count` to confirm email tracking.
- Queried Elasticsearch using `_search` and confirmed that CC fields are correctly stored in the new format:
  ```json
  "_source": {
    "ccNames": ["Shakira McLaughlin", "Jordyn Pfannerstill", "Damian Rice"],
    "ccAddresses": ["Greta.Wiegand@hotmail.com", "Morris_Beatty89@gmail.com", "Catherine75@gmail.com"]
  }
  ```
- Verified that older emails (without CC) are stored correctly without breaking the index schema.

## Release Notes

### Technical Improvements
- Added support for CC recipients in the `EmailMessage` API.
- Updated Elasticsearch logging to track CC recipients.

## Checklist

- [x] Unit tests added or updated.
- [x] Tested locally with **RabbitMQ**, **Redis**, **smtp4dev**, and **ElasticSearch**.
- [x] Checked for typos and formatting issues.
- [x] Release Notes are clear and understandable for non-developers.
- [x] Instructions for testers are self-contained and clear.
- [x] Self-reviewed the MR description and changes.
- [x] Has been approved by a developer.
- [x] Has been approved by a reviewer.

