### PR TITLE
Add docker publish workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,4 +1,4 @@
-name: "CI with dependencies from helm chart"
+name: "CI Tests with dependencies from helm chart"
 on: [pull_request, push]
 
 jobs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,26 @@
+name: "Docker Publish"
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: miaplaza
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            miaplaza/middlemail:latest
+            miaplaza/middlemail:${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,7 @@
 name: "Docker Publish"
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:
@@ -23,4 +22,4 @@ jobs:
           push: true
           tags: |
             miaplaza/middlemail:latest
-            miaplaza/middlemail:${{ github.sha }}
+            miaplaza/middlemail:${{ github.ref_name }}


### PR DESCRIPTION
## Short Summary of the Issue

Currently, there is no existing GitHub Action for publishing Docker images, which is necessary for deployment automation. 

## Changes made to Resolve the Issue

- Added a GitHub Action to automate Docker image publishing, ensuring a streamlined deployment process.
- Renamed the CI workflow for testing to improve clarity.

## Instructions for Testers

Once this has been merged, please test the following:

* [ ] Verify that the Docker image publishing GitHub Action runs successfully:
  * [ ] Ensure that a new Docker image is built and published correctly.
  * [ ] Confirm that the published image is available in [docker hub Miaplaza/Middlemail](https://hub.docker.com/r/miaplaza/middlemail).
* [ ] As a regression, verify that existing workflows are not affected:
  * [ ] Ensure that the other CI workflow remain functional with the new name.
    * [ ] Check that the testing process still executes as expected.

## Release Notes

**Technical improvements:**

* Added GitHub Action for Docker image publishing, streamlining deployment automation.

## Checklist

* [ ] Tested **No**, the current setup only triggers the job after ~pushing/merging into `master`~ releasing from a tag.
* [x] Checked for typos.
* [x] I have made sure that the Release Notes are understandable to a non-developer without the context of this Issue & Merge Request.
* [x] I have made sure that the Instructions for Testers are self-contained.
* [x] I have self-reviewed the Description and the Changes of this Pull Request.
* [ ] Has been approved by a developer.
* [ ] Has been approved by a reviewer.

