### PR TITLE
Allow reflection of middlemail-rabbitmq secret

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,6 +21,7 @@ jobs:
           --set elasticsearch.master.replicas=1 \
           --set elasticsearch.coordinating.replicas=1 \
           --set elasticsearch.data.replicas=1 \
+          --set elasticsearch.sysctlImage.tag=bookworm \
           --wait
         kubectl cluster-info
         kubectl get pods -o wide

--- a/helm/middlemail/templates/rabbitmq-secret.yaml
+++ b/helm/middlemail/templates/rabbitmq-secret.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "middlemail.labels" . | nindent 4 }}
   annotations:
-    {{- with .Values.secretAnnotations }}
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- with .Values.rabbitmq.secret.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 type: Opaque

--- a/helm/middlemail/templates/rabbitmq-secret.yaml
+++ b/helm/middlemail/templates/rabbitmq-secret.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "middlemail.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": before-hook-creation
-    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    {{- with .Values.secretAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}

--- a/helm/middlemail/templates/rabbitmq-secret.yaml
+++ b/helm/middlemail/templates/rabbitmq-secret.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": before-hook-creation
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
 type: Opaque
 data:
   rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}

--- a/helm/middlemail/templates/redis-secret.yaml
+++ b/helm/middlemail/templates/redis-secret.yaml
@@ -5,8 +5,9 @@ metadata:
   labels:
     {{- include "middlemail.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- with .Values.secretAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   redis-password: {{ randAlphaNum 10 | b64enc | quote }}

--- a/helm/middlemail/templates/redis-secret.yaml
+++ b/helm/middlemail/templates/redis-secret.yaml
@@ -5,9 +5,8 @@ metadata:
   labels:
     {{- include "middlemail.labels" . | nindent 4 }}
   annotations:
-    {{- with .Values.secretAnnotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
   redis-password: {{ randAlphaNum 10 | b64enc | quote }}

--- a/helm/middlemail/values.yaml
+++ b/helm/middlemail/values.yaml
@@ -88,3 +88,12 @@ backoff:
   # starting at multiplicator many seconds, then 2*multiplicator seconds, then
   # 4*multiplicator seconds, ...
   multiplicator: 60
+
+secretAnnotations:
+  # Annotations to add to the secrets created by this chart.
+  # Helm hooks annotations and reflector annotations are added.
+  # Reflector annotation here is used to allow the secret to be reflected by the EmberStack reflector in the target namespace.
+  # See https://github.com/emberstack/kubernetes-reflector?tab=readme-ov-file#1-annotate-the-source-secret-or-configmap
+  "helm.sh/hook": pre-install
+  "helm.sh/hook-delete-policy": before-hook-creation
+  reflector.v1.k8s.emberstack.com/reflection-allowed: "true"

--- a/helm/middlemail/values.yaml
+++ b/helm/middlemail/values.yaml
@@ -10,10 +10,7 @@ replicaCount: 1
 rabbitmq:
   provision: true
   secret:
-    annotations:
-      # This annotation is used by the EmberStack reflector to allow the secret to be reflected in the target namespace
-      # See https://github.com/emberstack/kubernetes-reflector?tab=readme-ov-file#1-annotate-the-source-secret-or-configmap
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    annotations: {}
 
   # When these are not set, this chart is going to deploy its own RabbitMQ instance and connect to it.
   # It will then be accessible in your cluster as the service RELEASE-rabbitmq-0

--- a/helm/middlemail/values.yaml
+++ b/helm/middlemail/values.yaml
@@ -9,6 +9,11 @@ replicaCount: 1
 
 rabbitmq:
   provision: true
+  secret:
+    annotations:
+      # This annotation is used by the EmberStack reflector to allow the secret to be reflected in the target namespace
+      # See https://github.com/emberstack/kubernetes-reflector?tab=readme-ov-file#1-annotate-the-source-secret-or-configmap
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
 
   # When these are not set, this chart is going to deploy its own RabbitMQ instance and connect to it.
   # It will then be accessible in your cluster as the service RELEASE-rabbitmq-0
@@ -88,12 +93,3 @@ backoff:
   # starting at multiplicator many seconds, then 2*multiplicator seconds, then
   # 4*multiplicator seconds, ...
   multiplicator: 60
-
-secretAnnotations:
-  # Annotations to add to the secrets created by this chart.
-  # Helm hooks annotations and reflector annotations are added.
-  # Reflector annotation here is used to allow the secret to be reflected by the EmberStack reflector in the target namespace.
-  # See https://github.com/emberstack/kubernetes-reflector?tab=readme-ov-file#1-annotate-the-source-secret-or-configmap
-  "helm.sh/hook": pre-install
-  "helm.sh/hook-delete-policy": before-hook-creation
-  reflector.v1.k8s.emberstack.com/reflection-allowed: "true"


### PR DESCRIPTION
This will [allow](https://github.com/emberstack/kubernetes-reflector?tab=readme-ov-file#1-annotate-the-source-secret-or-configmap) the reflection of `middlemail-rabbitmq` secret in other namespaces.

**Please note** that this annotation will **_not_** automatically create this secret in other namespaces but it will allow other namespaces to fetch the latest value from this secret using another annotation, whenever the source secret changes, using [reflector operator.](https://github.com/emberstack/kubernetes-reflector)
